### PR TITLE
docs: clarify recents query fallback behavior

### DIFF
--- a/docs/reuse-api.md
+++ b/docs/reuse-api.md
@@ -1,0 +1,28 @@
+# Reuse API
+
+## GET `/api/recents`
+
+Returns the latest unique non-draft meals for the authenticated user, sorted by most recent first.
+
+### Query params
+
+- `limit` (optional, default `5`)
+  - Parsed as a number.
+  - If `limit` is not a valid number (for example `limit=abc`), the route falls back to `5`.
+- `offset` (not supported)
+  - Any `offset` value (including invalid or negative values) is ignored.
+  - The response falls back to default behavior (same result as omitting `offset`).
+
+### Examples
+
+```http
+GET /api/recents?limit=abc
+```
+
+Uses fallback `limit=5`.
+
+```http
+GET /api/recents?offset=-10
+```
+
+`offset` is ignored; response is the same as `GET /api/recents`.


### PR DESCRIPTION
## Summary
- add `docs/reuse-api.md` with GET `/api/recents` behavior
- document fallback handling for invalid `limit` (`limit=abc` -> default `5`)
- document that `offset` is unsupported and ignored, including invalid/negative values
- include concise request examples for both fallback cases

## Validation
- npm test

Closes #29
