### PR TITLE
Issue #33: add messenger smoke doc

### DIFF
--- a/docs/messenger-smoke.md
+++ b/docs/messenger-smoke.md
@@ -1,0 +1,3 @@
+# Messenger Smoke
+
+Shard messenger dev tooling is enabled.


### PR DESCRIPTION
## Summary
- add `docs/messenger-smoke.md`
- include short note confirming shard messenger dev tooling is enabled

## Validation
- `test -f docs/messenger-smoke.md && grep -n "Shard messenger dev tooling is enabled." docs/messenger-smoke.md`

Closes #33
