### PR TITLE
docs: add messenger smoke note for coding-02 path visibility

### DIFF
--- a/docs/messenger-smoke-2.md
+++ b/docs/messenger-smoke-2.md
@@ -1,0 +1,1 @@
+Messenger smoke check: coding-02 path visibility works.


### PR DESCRIPTION
## Summary
- add docs/messenger-smoke-2.md
- document that coding-02 path visibility works in one sentence

## Validation
- verified file contents via read tool
- git status --short reviewed before commit (only target file staged)

Refs #35