### PR TITLE
Issue #37: add protocol smoke artifact doc

### DIFF
--- a/docs/protocol-smoke.md
+++ b/docs/protocol-smoke.md
@@ -1,0 +1,1 @@
+protocol artifact dispatch works


### PR DESCRIPTION
## Summary
- add `docs/protocol-smoke.md` with the requested protocol smoke sentence

## Validation
- verified file content with repository read tool: `docs/protocol-smoke.md` contains exactly `protocol artifact dispatch works`

Closes #37