### PR TITLE
Issue #44: Add single-ack thread smoke doc

### DIFF
--- a/docs/protocol-single-ack-smoke.md
+++ b/docs/protocol-single-ack-smoke.md
@@ -1,0 +1,1 @@
+single ack guard works


### PR DESCRIPTION
## Summary
- add `docs/protocol-single-ack-smoke.md` with the exact required content

## Validation
- `read docs/protocol-single-ack-smoke.md` shows: `single ack guard works`

Closes #44
