### PR TITLE
Issue #48: Add anti-loop stability smoke protocol doc

### DIFF
--- a/docs/protocol-anti-loop-stability-smoke.md
+++ b/docs/protocol-anti-loop-stability-smoke.md
@@ -1,0 +1,1 @@
+anti loop stability holds


### PR DESCRIPTION
## Summary
- add `docs/protocol-anti-loop-stability-smoke.md`
- set file content to the exact required text: `anti loop stability holds`

## Validation
- verified `docs/protocol-anti-loop-stability-smoke.md` contains exactly `anti loop stability holds`
