### PR TITLE
Issue #54: add shard orchestration smoke diagnostics note

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,6 @@ npm run test:perf
 - Product overview: [`docs/product-overview.md`](docs/product-overview.md)
 - Observability queries: [`docs/auth-profile-observability.md`](docs/auth-profile-observability.md)
 - M1 release checklist: [`docs/m1-release-checklist.md`](docs/m1-release-checklist.md)
+- Reuse API & telemetry: [`docs/reuse-api.md`](docs/reuse-api.md)
+- Shard orchestration smoke test guide: [`docs/shard-orchestration-smoke.md`](docs/shard-orchestration-smoke.md) (issue #54) – describes how running `npm run test -- --help` proves the shard-aware Vitest CLI is still reachable.
 - Vision source of truth: [`VISION.md`](VISION.md)

--- a/docs/shard-orchestration-smoke.md
+++ b/docs/shard-orchestration-smoke.md
@@ -1,0 +1,14 @@
+# Shard Orchestration Smoke Test
+
+## Purpose
+Issue #54 asked for a quick smoke reference that keeps the shard-aware Vitest CLI in the open. This page explains why we run the light check and where to look when the orchestration layer needs reassurance.
+
+## How to verify locally
+1. Ensure dependencies are installed (`npm install`) and your working tree is clean so the smoke entry point has a known baseline.
+2. Run `npm run test -- --help`. The script resolves to `vitest run --help`, so its output should start with the familiar `vitest/4.0.18` banner and enumerate options such as `--shard <shards>`, `--run`, and `--watch`. Seeing `--shard <shards>` in that list proves the shard hooks are exposed to CLI consumers without actually executing suites.
+3. Confirm the command exits with `0` and prints no errors. A clean help output means the CLI layer boots and lists the shard controls while leaving the real suites untouched.
+
+## What changed
+- Added this issue #54–driven reference page so the smoke test has a discoverable home.
+- Linked the new guide from the README documentation list so the smoke path is easy to find.
+- Documented that the verification step is `npm run test -- --help`, and that it surfaces the `vitest run` help text with the shard options we care about.


### PR DESCRIPTION
## Summary
- add `docs/shard-orchestration-smoke.md` with required sections: Purpose, How to verify locally, and What changed
- document `npm run test -- --help` as the verification command and explain expected shard-related output
- link the new smoke guide from README so it is discoverable

## Validation
- `npm run test -- --help`

Closes #54
